### PR TITLE
Agenda is now dynamic via SSI

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -1,6 +1,0 @@
-<li>Group contact policy: email & SMS</li>
-<li>Irc channel ops policy</li>
-<li>Spam control in IRC</li>
-<li>Bonzai Brawl (April 11th)<br/><a href="http://bonzai.cs.mtu.edu/">website</a></li>
-<li>Security lab</li>
-<li>3D printer workshop</li>

--- a/agenda.html
+++ b/agenda.html
@@ -1,0 +1,6 @@
+<li>Group contact policy: email & SMS</li>
+<li>Irc channel ops policy</li>
+<li>Spam control in IRC</li>
+<li>Bonzai Brawl (April 11th)<br/><a href="http://bonzai.cs.mtu.edu/">website</a></li>
+<li>Security lab</li>
+<li>3D printer workshop</li>

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,4 @@
 ---
-layout: none
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/minutes/index.html
+++ b/minutes/index.html
@@ -18,12 +18,7 @@ title: Minutes
     <div class="pure-u-1-2">
         <h1>Agenda</h1>
         <ol>
-            <li>Group contact policy: email & SMS</li>
-            <li>Irc channel ops policy</li>
-            <li>Spam control in IRC</li>
-            <li>Bonzai Brawl (April 11th)<br/><a href="http://bonzai.cs.mtu.edu/">website</a></li>
-            <li>Security lab</li>
-            <li>3D printer workshop</li>
+            <--#include virtual="agenda.html" -->
         </ol>
     </div>
 </div>


### PR DESCRIPTION
Uses SSI to read agenda.html in the root dir. minutes/index.html is executable to mark that it will be processed for SSI by apache. Also squeeking in an update to feed.xml as it didn't need to have 'layout: none' jekyll was throwing a warning when building it because there is no layout: none.