### PR TITLE
Fixed broken email link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site
 name: CCaWMU
 title: Computer Club at Western Michigan University
-email: "rso-cclub@wmich.edu"
+email: "rso_cclub@wmich.edu"
 description: "The Computer Club at Western Michigan University."
 baseurl: ""
 url: "https://cclub.cs.wmich.edu/"


### PR DESCRIPTION
fixed email from being rso-cclub@wmich.edu to rso_cclub@wmich.edu.