### PR TITLE
Modernize front page verbiage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,6 @@ title: Home
 ---
 {% include header.html %}
 
-<div class="content">
-    <div style="text-align: center;" class="c-box">
-        <h1> READ THE UPDATED CONSTITUTION HERE: <a href="https://github.com/ccowmu/constitution/pull/5">CONSTITUTION</a></h1>
-    </div>
-</div>
-
 <a data-flickr-embed="true" href="https://www.flickr.com/photos/129058274@N06/albums/72157648511414994" title="Landing"><img src="https://live.staticflickr.com/65535/51583944297_c988c58014_z.jpg" 
     width="100%" height="500" alt="Landing"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
@@ -17,22 +11,22 @@ title: Home
     <div style="text-align: center;" class="c-box">
         <h1>Let us introduce ourselves</h1>
 
-        <p>We are an organic, laid back learning environment, and WMU's resident
+        <p>We are an organic, laid-back learning environment and WMU's resident
             hackerspace. We value curiosity as much as we do knowledge, and time has
             shown that everyone has something to offer.</p>
 
         <p>With our own office and the resources in it, our greatest
-            resource remains our people, and after almost 40 years at WMU, we've
+            resource remains our people. After 50+ years at WMU, we've
             gained hundreds of great members doing remarkable things at companies
-            like Google, Apple, LinkedIn, and RDIO.</p>
+            like Google, Apple, Amazon, and many others.</p>
 
         <p>Regardless of what we know or who we are before
             joining, we grow and learn a tremendous amount from each other.
         </p>
 
-        <p>We hope you'll come by for one of our weekly meetings on
-            <strong class="big">6pm on Thursdays at 2225 Kohrman Hall.</a> </strong>
-            If you can't make it in person, check out our linktree below for a link to our twitch account where we will be streaming the meeting weekly!
+        <p>We hope you'll come by for one of our weekly meetings at
+            <strong class="big">6 pm on Thursdays in 2225 Kohrman Hall.</a> </strong>
+            If you can't make it in person, check out our Linktree below for a link to our Twitch account, where we'll be streaming the meeting weekly!
         </p>
 
         <h2>Want to learn more?</h2>
@@ -41,11 +35,11 @@ title: Home
             Check out our <a href="https://linktr.ee/ccawmu">linktree</a> for other places to find us.
         </p>
 
-        <p>The best way to see if we're the right fit is stopping by
+        <p>The best way to see if we're the right fit is to stop by
             a meeting to see for yourself.</p>
 
         <p>If you're even a little interested in security, programming,
-            hardware, electronics or have an idea for your own project then chances
+            hardware, electronics, or have an idea for your own project, then chances
             are you'll find a friend in us. See what a meeting might entail by checking
             out our <a href="{{ "/minutes/" | prepend: site.baseurl }}">meeting minutes</a>.</p>
 


### PR DESCRIPTION
Modernize, update outdated references, fix typos, and remove the Constitution banner.