### PR TITLE
Site configuration updates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,8 @@
-baseURL = "/"
+baseURL = "https://cclub.cs.wmich.edu/"
 languageCode = "en-us"
 title = "CCAWMU"
-relativeURLs = true
-canonifyURLs = false
+relativeURLs = false
+canonifyURLs = true
 enableRobotsTXT = true
 
 [params]

--- a/content/_index.md
+++ b/content/_index.md
@@ -15,7 +15,7 @@ description: 'WMU''s Resident Hackerspace Since 1976.'
   </div>
 </div>
 <div class='hero-actions'>
-  <a href='{{ "join" | absURL }}' class='join-button'>Join the Club</a>
+  <a href='/join' class='join-button'>Join the Club</a>
 </div>
 {{< /hero >}}
 

--- a/layouts/shortcodes/join-steps.html
+++ b/layouts/shortcodes/join-steps.html
@@ -12,7 +12,7 @@
                             <span class="btn-icon">📱</span>
                             Download Element
                         </a>
-                        <a href="/chat/" class="btn btn-secondary" target="_blank" rel="noopener">
+                        <a href="https://cclub.cs.wmich.edu/chat" class="btn btn-secondary" target="_blank" rel="noopener">
                             <span class="btn-icon">🌐</span>
                             Use Web App
                         </a>


### PR DESCRIPTION
This pull request updates site configuration and several links to use absolute URLs, ensuring consistency and proper navigation when deployed to the production domain. The most important changes are grouped below:

Site configuration updates:

* Changed `baseURL` in `config.toml` to the production domain (`https://cclub.cs.wmich.edu/`), set `relativeURLs` to false, and enabled `canonifyURLs` for correct URL handling.

Link updates for navigation:

* Updated the "Join the Club" button in `content/_index.md` to use an absolute path (`/join`) instead of a template filter.
* Updated the "Use Web App" button in `layouts/shortcodes/join-steps.html` to link directly to the production chat URL (`https://cclub.cs.wmich.edu/chat`).