### PR TITLE
URL fixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ title = "CCAWMU"
 relativeURLs = false
 canonifyURLs = true
 enableRobotsTXT = true
+ignoreErrors = ["error-disable-taxonomy"]
 
 [params]
 	description = "WMU's Resident Hackerspace Since 1976."

--- a/minutes/config.toml
+++ b/minutes/config.toml
@@ -1,13 +1,13 @@
-baseURL = "/minutes/"
-relativeURLs = true
-canonifyURLs = false
-disableKinds = ["taxonomy", "RSS", "sitemap"]
+baseURL = "https://cclub.cs.wmich.edu/minutes/"
+relativeURLs = false
+canonifyURLs = true
+disableKinds = ["term", "RSS", "sitemap"]
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
 [permalinks]
-  minutes = "/:contentbasename/"
+  minutes = "/:filename/"
 [outputs]
 home = ["HTML", "JSON"]
 


### PR DESCRIPTION
This pull request updates configuration files to improve site behavior and URL handling for both the main site and the minutes section. The changes focus on URL canonicalization, error handling, and taxonomy settings.

Main site configuration improvements:

* Added `ignoreErrors = ["error-disable-taxonomy"]` to the main `config.toml` to prevent build failures related to taxonomy errors.

Minutes section configuration updates:

* Changed `baseURL` in `minutes/config.toml` to use the full production URL instead of a relative path, ensuring correct link generation.
* Enabled canonical URLs and disabled relative URLs for the minutes section to improve SEO and consistency.
* Updated `disableKinds` to exclude `"term"` instead of `"taxonomy"` for more precise control over generated content types.
* Modified the `minutes` permalink structure to use `:filename:` instead of `:contentbasename:`, improving clarity and file referencing.